### PR TITLE
Gomguk 71 selection layer 생성

### DIFF
--- a/src/classes/Line.ts
+++ b/src/classes/Line.ts
@@ -31,4 +31,10 @@ export default class Line {
             return acc + token.getText();
         }, '');
     }
+    get firstToken() {
+        return this.tokens[0];
+    }
+    get lastToken() {
+        return this.tokens[this.tokens.length - 1];
+    }
 }

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -6,6 +6,11 @@
             class="textLayer"
             :data-page-index="pageIndex"
         ></div>
+        <selection-layer
+            class="selectionLayer"
+            ref="$selectionLayer"
+            :pageIndex="pageIndex"
+        ></selection-layer>
     </div>
 </template>
 
@@ -18,6 +23,7 @@ import { usePdfStore } from '@/store/pdf';
 import { PageViewport, PDFPageProxy } from 'pdfjs-dist';
 import * as pdfjsLib from 'pdfjs-dist';
 import TOKEN from '@/constants/TOKEN';
+import SelectionLayer from '@/components/SelectionLayer.vue';
 
 const props = defineProps({
     pageIndex: {
@@ -29,6 +35,7 @@ const pdfStore = usePdfStore();
 const $pdfPage = ref<HTMLDivElement>();
 const $pdfLayer = ref<HTMLCanvasElement>();
 const $textLayer = ref<HTMLDivElement>();
+const $selectionLayer = ref();
 const viewport = ref<PageViewport>();
 
 let page: PDFPageProxy;
@@ -62,13 +69,16 @@ async function renderPage(page: PDFPageProxy, viewport: PageViewport) {
     await renderPdfLayer(page, viewport, ctx);
     await renderTextLayer(page, viewport);
 }
+
 function setPageSize(viewport: PageViewport) {
-    if (!$pdfPage.value || !$pdfLayer.value) return;
+    if (!$pdfPage.value || !$pdfLayer.value || !$selectionLayer.value) return;
 
     $pdfPage.value.style.width = viewport.width + 'px';
     $pdfPage.value.style.height = viewport.height + 'px';
     $pdfLayer.value.width = viewport.width;
     $pdfLayer.value.height = viewport.height;
+    $selectionLayer.value.$el.width = viewport.width;
+    $selectionLayer.value.$el.height = viewport.height;
 }
 
 /**

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -153,7 +153,8 @@ function addTokenInfo(nodes: Node[]) {
     position: relative;
     margin: 0 auto 1rem auto;
     .pdfLayer,
-    .textLayer {
+    .textLayer,
+    .selectionLayer {
         position: absolute;
         left: 0;
         top: 0;
@@ -180,6 +181,14 @@ function addTokenInfo(nodes: Node[]) {
             color: transparent;
             background: green;
         }
+    }
+    .selectionLayer {
+        z-index: 100;
+        opacity: 0.5;
+    }
+    .textLayer {
+        z-index: 200;
+        opacity: 0;
     }
 }
 </style>

--- a/src/components/SelectionLayer.vue
+++ b/src/components/SelectionLayer.vue
@@ -1,0 +1,69 @@
+<template>
+    <canvas ref="$selectionLayer" class="selectionLayer"></canvas>
+</template>
+
+<script setup lang="ts">
+/**
+ * SelectionLayer는 pdf에서 selection된 영역을 그리는 레이어 컴포넌트 입니다.
+ */
+import { defineProps, ref, onMounted } from 'vue';
+import { useSelectionStore } from '@/store/selection';
+import Line from '@/classes/Line';
+
+const props = defineProps({
+    pageIndex: {
+        type: Number,
+        required: true,
+    },
+});
+const selectionStore = useSelectionStore();
+const $selectionLayer = ref<HTMLCanvasElement>();
+const ctx = ref<CanvasRenderingContext2D | null>(null);
+
+onMounted(async () => {
+    if (!$selectionLayer.value) return;
+
+    ctx.value = $selectionLayer.value.getContext('2d');
+});
+
+selectionStore.$subscribe((_, state) => {
+    const { selectedPageIndex, isSelectionExist, selectedLines } = state;
+    if (!isSelectionExist) {
+        clearSelectionLayer();
+        return;
+    }
+
+    if (selectedPageIndex !== props.pageIndex) {
+        clearSelectionLayer();
+        return;
+    }
+
+    clearSelectionLayer();
+
+    if (!selectedLines) return;
+    drawLines(selectedLines as Line[]);
+});
+
+function clearSelectionLayer() {
+    if (!ctx.value || !$selectionLayer.value) return;
+
+    ctx.value.clearRect(
+        0,
+        0,
+        $selectionLayer.value.width,
+        $selectionLayer.value.height
+    );
+}
+
+function drawLines(lines: Line[]) {
+    lines.forEach((line) => {
+        if (!ctx.value) return;
+
+        const { left, top, width, height } = line.rect;
+        ctx.value.beginPath();
+        ctx.value.rect(left, top, width, height);
+        ctx.value.fillStyle = 'red';
+        ctx.value.fill();
+    });
+}
+</script>

--- a/src/utils/clearSelection.ts
+++ b/src/utils/clearSelection.ts
@@ -1,0 +1,17 @@
+/**
+ * selection 영역을 지웁니다.
+ */
+
+export default function clearSelection() {
+    const selection = window.getSelection();
+
+    if (!selection) return;
+    if (selection.empty) {
+        selection.empty();
+        return;
+    }
+    if (selection.removeAllRanges) {
+        selection.removeAllRanges();
+        return;
+    }
+}

--- a/src/utils/setSelection.ts
+++ b/src/utils/setSelection.ts
@@ -1,4 +1,5 @@
 import Line from '@/classes/Line';
+import clearSelection from '@/utils/clearSelection';
 
 export default function setSelection(selectedLines: Line[]) {
     const firstLine = selectedLines[0];
@@ -21,6 +22,6 @@ export default function setSelection(selectedLines: Line[]) {
 
     if (!selection) return;
 
-    selection.removeAllRanges();
+    clearSelection();
     selection.addRange(range);
 }

--- a/src/utils/setSelection.ts
+++ b/src/utils/setSelection.ts
@@ -1,0 +1,26 @@
+import Line from '@/classes/Line';
+
+export default function setSelection(selectedLines: Line[]) {
+    const firstLine = selectedLines[0];
+    const lastLine = selectedLines[selectedLines.length - 1];
+
+    if (!firstLine || !lastLine) return;
+
+    const range = new Range();
+    const anchorToken = firstLine.firstToken;
+    const anchorOffset = anchorToken?.startOffset;
+    const focusToken = lastLine.lastToken;
+    const focusOffset = focusToken?.endOffset;
+
+    if (!anchorToken.$el || !focusToken.$el) return;
+
+    range.setStart(anchorToken.$el.firstChild as Node, anchorOffset as number);
+    range.setEnd(focusToken.$el.firstChild as Node, focusOffset as number);
+
+    const selection = document.getSelection();
+
+    if (!selection) return;
+
+    selection.removeAllRanges();
+    selection.addRange(range);
+}

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -35,6 +35,8 @@ import POPUP from '@/constants/POPUP';
 import SelectionPopup from '@/components/popup/SelectionPopup.vue';
 import SECLECTION from '@/constants/SELECTION';
 import createUpperLimit from '@/utils/createUpperLimit';
+import Line from '@/classes/Line';
+import setSelection from '@/utils/setSelection';
 
 type PageIndex = {
     idx: number;
@@ -98,6 +100,8 @@ function selectionEndHandler(evt: MouseEvent) {
     };
     setPopupPosition(mousePos);
     isPopupShow.value = true;
+
+    setSelection(selectionStore.selectedLines as Line[]);
 }
 function createPageIndexList(fileName: string, maxPageNum: number) {
     const list = [];

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -37,7 +37,7 @@ import SECLECTION from '@/constants/SELECTION';
 import createUpperLimit from '@/utils/createUpperLimit';
 import Line from '@/classes/Line';
 import setSelection from '@/utils/setSelection';
-
+import clearSelection from '@/utils/clearSelection';
 type PageIndex = {
     idx: number;
     key: string;
@@ -78,6 +78,7 @@ pdfStore.$subscribe('doc', (state: PdfState) => {
 
 function selectionStartHandler() {
     selectionStore.setRange(null);
+    clearSelection();
     isPopupShow.value = false;
 }
 function selectionChangeHandler() {

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -55,31 +55,9 @@ const $pageContainer = ref();
 const isPopupShow = ref<boolean>(false);
 
 onMounted(() => {
-    $pdfView.value.addEventListener('mousedown', () => {
-        selectionStore.setRange(null);
-        isPopupShow.value = false;
-    });
-    document.addEventListener('selectionchange', () => {
-        const selection = window.getSelection();
-        if (selection && !selection.isCollapsed) {
-            selectionStore.setRange(selection.getRangeAt(0));
-        }
-    });
-    document.addEventListener('mouseup', (evt: MouseEvent) => {
-        if (!selectionStore.range) {
-            isPopupShow.value = false;
-            return;
-        }
-
-        const { clientX, clientY } = evt;
-        const { scrollLeft, scrollTop } = $pdfView.value;
-        const mousePos: Pos = {
-            x: clientX + scrollLeft,
-            y: clientY + scrollTop,
-        };
-        setPopupPosition(mousePos);
-        isPopupShow.value = true;
-    });
+    $pdfView.value.addEventListener('mousedown', selectionStartHandler);
+    document.addEventListener('selectionchange', selectionChangeHandler);
+    document.addEventListener('mouseup', selectionEndHandler);
 });
 
 pdfStore.$subscribe('doc', (state: PdfState) => {
@@ -96,6 +74,31 @@ pdfStore.$subscribe('doc', (state: PdfState) => {
     );
 });
 
+function selectionStartHandler() {
+    selectionStore.setRange(null);
+    isPopupShow.value = false;
+}
+function selectionChangeHandler() {
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) {
+        selectionStore.setRange(selection.getRangeAt(0));
+    }
+}
+function selectionEndHandler(evt: MouseEvent) {
+    if (!selectionStore.range) {
+        isPopupShow.value = false;
+        return;
+    }
+
+    const { clientX, clientY } = evt;
+    const { scrollLeft, scrollTop } = $pdfView.value;
+    const mousePos: Pos = {
+        x: clientX + scrollLeft,
+        y: clientY + scrollTop,
+    };
+    setPopupPosition(mousePos);
+    isPopupShow.value = true;
+}
 function createPageIndexList(fileName: string, maxPageNum: number) {
     const list = [];
     for (let i = 1; i <= maxPageNum; i++) {


### PR DESCRIPTION
## 추가된 기능 & 변경 사항
selection한 영역을 그리는 selection-layer 컴포넌트 추가

### setSelection 유틸과 clearSelection 유틸이 추가된 이유
![scale-fast](https://user-images.githubusercontent.com/40891497/195588338-f4031971-1abc-45c3-947f-7c4f3ebc72b8.gif)
selection이 튀는 현상이 있어 이를 수정하고자 함

마우스가 text 영역을 벗어나면 위와 같이 튀는 현상이 있고 selection-layer에는 튀는 현상이 있지 않지만 whale의 경우 아래처럼 search button이 엉뚱하게 나타나는 문제가 생김
![image](https://user-images.githubusercontent.com/40891497/195589493-15b314c5-611d-4d42-bca6-01f459c78ba5.png)
(초록 영역: 실제 selection 영역, 빨간 영역: selection-layer에 그려진 selection 영역)

따라서 실제 selection 영역을 재조정해야하고 이를 위해 clearSelection과 setSelection을 추가함

## 공유할 문서

## Jira 티켓
https://memorier.atlassian.net/browse/GOMGUK-71?atlOrigin=eyJpIjoiNzliYTk5MjdmYTc2NDU2YzgyZWVmYTI5YzAyYjZmZmMiLCJwIjoiaiJ9

## 데모 사이트

https://ssu-memorier.github.io/gomguk-viewer-fe/
