### PR TITLE
Gomguk 86 확대, 축소 버튼 추가

### DIFF
--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -101,4 +101,10 @@ export default class Page {
             height: this.viewport.value?.height || 0,
         };
     }
+    async getPdfLayer() {
+        const canvas = document.createElement('canvas');
+        await this.renderPdfLayer(canvas);
+
+        return canvas;
+    }
 }

--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -3,6 +3,8 @@ import { IViewportOption } from '@/Interface/IViewportOption';
 import * as pdfjs from 'pdfjs-dist';
 import TOKEN from '@/constants/TOKEN';
 import { SizeType } from '@/types/SizeType';
+import resizeCanvas from '@/utils/resizeCanvas';
+
 export default class Page {
     #pageProxy: pdfjs.PDFPageProxy;
     viewport = ref<pdfjs.PageViewport>();
@@ -20,8 +22,11 @@ export default class Page {
      */
     async renderPdfLayer($layer: HTMLCanvasElement) {
         const ctx = $layer.getContext('2d');
+
         if (!ctx) return;
         if (!this.viewport.value) return;
+
+        resizeCanvas($layer, this.size);
 
         const renderContext = {
             canvasContext: ctx,

--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -5,9 +5,11 @@ import TOKEN from '@/constants/TOKEN';
 export default class Page {
     #pageProxy: pdfjs.PDFPageProxy;
     viewport: pdfjs.PageViewport;
+    option: IViewportOption;
 
     constructor(pageProxy: pdfjs.PDFPageProxy, option: IViewportOption) {
         this.#pageProxy = pageProxy;
+        this.option = option;
         this.viewport = this.#pageProxy.getViewport(option);
     }
 
@@ -32,6 +34,8 @@ export default class Page {
      * @param $layer 텍스트 요소(span,br)가 들어갈 컨테이너
      */
     async renderTextLayer($layer: HTMLDivElement) {
+        $layer.innerHTML = '';
+
         pdfjs.renderTextLayer({
             textContent: await this.#pageProxy.getTextContent(),
             container: $layer,
@@ -78,6 +82,7 @@ export default class Page {
         });
     }
     updateViewport(option: IViewportOption) {
+        this.option = option;
         this.viewport = this.#pageProxy.getViewport(option);
     }
     get pageNum() {

--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -103,7 +103,7 @@ export default class Page {
             height: this.viewport.value?.height || 0,
         };
     }
-    async getPdfLayer() {
+    async createPdfLayer() {
         const canvas = document.createElement('canvas');
         await this.renderPdfLayer(canvas);
 

--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue';
 import { IViewportOption } from '@/Interface/IViewportOption';
 import * as pdfjs from 'pdfjs-dist';
 import TOKEN from '@/constants/TOKEN';
-
+import { SizeType } from '@/types/SizeType';
 export default class Page {
     #pageProxy: pdfjs.PDFPageProxy;
     viewport = ref<pdfjs.PageViewport>();
@@ -90,7 +90,7 @@ export default class Page {
     get pageNum() {
         return this.#pageProxy.pageNumber;
     }
-    get size() {
+    get size(): SizeType {
         return {
             width: this.viewport.value?.width || 0,
             height: this.viewport.value?.height || 0,

--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -40,8 +40,10 @@ export default class Page {
      * text layer를 랜더링하여 텍스트를 선택할 수 있게 합니다.
      * @param $layer 텍스트 요소(span,br)가 들어갈 컨테이너
      */
-    async renderTextLayer($layer: HTMLDivElement) {
-        $layer.innerHTML = '';
+    async renderTextLayer($layer: HTMLElement | DocumentFragment) {
+        if ($layer instanceof HTMLElement) {
+            $layer.innerHTML = '';
+        }
         if (!this.viewport.value) return;
 
         pdfjs.renderTextLayer({
@@ -106,5 +108,11 @@ export default class Page {
         await this.renderPdfLayer(canvas);
 
         return canvas;
+    }
+    async createTextLayerFragment() {
+        const fragment = document.createDocumentFragment();
+        await this.renderTextLayer(fragment);
+
+        return fragment;
     }
 }

--- a/src/classes/Page.ts
+++ b/src/classes/Page.ts
@@ -90,4 +90,10 @@ export default class Page {
     get pageNum() {
         return this.#pageProxy.pageNumber;
     }
+    get size() {
+        return {
+            width: this.viewport.value?.width || 0,
+            height: this.viewport.value?.height || 0,
+        };
+    }
 }

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -31,11 +31,11 @@
  */
 import { defineProps, ref, onMounted, watch, computed } from 'vue';
 import { usePdfStore } from '@/store/pdf';
+import { PageViewport } from 'pdfjs-dist';
 import SelectionLayer from '@/components/layer/SelectionLayer.vue';
 import HighlightLayer from '@/components/layer/HighlightLayer.vue';
-import Page from '@/classes/Page';
 import copyCanvas from '@/utils/copyCanvas';
-import { PageViewport } from 'pdfjs-dist';
+import Page from '@/classes/Page';
 
 const props = defineProps({
     pageIndex: {
@@ -43,6 +43,8 @@ const props = defineProps({
         required: true,
     },
 });
+
+const isScaleChanging = ref<boolean>(false);
 const pdfStore = usePdfStore();
 const $pdfPage = ref<HTMLDivElement>();
 const $highResolutionLayer = ref<HTMLCanvasElement>();
@@ -50,7 +52,6 @@ const $textLayer = ref<HTMLDivElement>();
 const $selectionLayer = ref();
 const $highlightLayer = ref();
 const $lowResolutionLayer = ref<HTMLCanvasElement>();
-const isScaleChanging = ref<boolean>(false);
 
 let page: Page | undefined;
 const highResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -123,16 +123,15 @@ function setPageSize(width: number, height: number) {
 }
 
 function copyCanvas(ctx: CanvasRenderingContext2D) {
-    const width = ctx.canvas.width;
-    const height = ctx.canvas.height;
-    const imgData = ctx.getImageData(0, 0, width, height);
-    const newCanvas = document.createElement('canvas');
+    const { width, height } = ctx.canvas;
+    const originImg = ctx.getImageData(0, 0, width, height);
+    const copiedCanvas = document.createElement('canvas');
 
-    newCanvas.width = width;
-    newCanvas.height = height;
-    newCanvas.getContext('2d')?.putImageData(imgData, 0, 0);
+    copiedCanvas.width = width;
+    copiedCanvas.height = height;
+    copiedCanvas.getContext('2d')?.putImageData(originImg, 0, 0);
 
-    return newCanvas;
+    return copiedCanvas;
 }
 
 function drawLowResolutionLayer(

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -179,7 +179,11 @@ function drawHighResolutionLayer(highResolutionCanvas: HTMLCanvasElement) {
 async function renderTextLayer() {
     if (!page || !$textLayer.value) return;
 
-    await page.renderTextLayer($textLayer.value);
+    const fragment = await page.createTextLayerFragment();
+    if (!fragment) return;
+
+    $textLayer.value.innerHTML = '';
+    $textLayer.value.appendChild(fragment);
     page.addTokenInfo($textLayer.value);
 }
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -81,7 +81,6 @@ onMounted(async () => {
 
     originalPageSize = page.size;
     await renderPage(page.size);
-    await renderTextLayer(page.size);
 
     watch(page.viewport, async () => {
         await changePageSize(page.size);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -110,8 +110,8 @@ onMounted(async () => {
     await drawHighResolutionLayer(originalPageSize);
     await renderTextLayer();
 
-    watch(page.viewport, async (newViewport, oldViewport) => {
-        if (!newViewport || !oldViewport) return;
+    watch(page.viewport, async (newViewport) => {
+        if (!newViewport) return;
 
         isChangingSize.value = true;
         const newPageSize: Size = {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -66,7 +66,7 @@ const debouncedHighResolutionRender = createDebounce(
         resizeElement($textLayer.value, newPageSize);
 
         originalPageSize = newPageSize;
-        await drawHighResolutionLayer(newPageSize);
+        await drawHighResolutionLayer();
         await renderTextLayer();
         if ($highResolutionLayer.value) {
             isChangingSize.value = false;
@@ -99,7 +99,7 @@ onMounted(async () => {
 
     originalPageSize = page.size;
     resizePage(originalPageSize);
-    await drawHighResolutionLayer(originalPageSize);
+    await drawHighResolutionLayer();
     await renderTextLayer();
 
     watch(page.viewport, async (newViewport) => {
@@ -157,11 +157,11 @@ function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {
     lowResolutionCtx.value.drawImage(originScaleCanvas, 0, 0);
 }
 
-async function drawHighResolutionLayer(pageSize: SizeType) {
+async function drawHighResolutionLayer() {
     if (!page || !highResolutionCtx.value) return;
 
     const tempCanvas = document.createElement('canvas');
-    resizeCanvas(tempCanvas, pageSize);
+    resizeCanvas(tempCanvas, page.size);
     await page.renderPdfLayer(tempCanvas);
 
     highResolutionCtx.value.drawImage(tempCanvas, 0, 0);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -78,24 +78,24 @@ onMounted(async () => {
         isScaleChanging.value = false;
     });
 });
-
-async function scaleChange(viewport: PageViewport, oldViewport: PageViewport) {
-    if (
-        !page ||
-        !highResolutionctx.value ||
-        !lowResolutionCtx.value ||
-        !$highResolutionLayer.value ||
-        !$textLayer.value
-    )
-        return;
+/**
+ * scaleChange는 PDF 페이지의 스케일을 변경하는 로직으로 아래의 과정을 거칩니다.
+ * canvas확대/축소 (해상도가 낮아짐) -> 고해상도 canvas를 로딩
+ * @param newViewport
+ * @param oldViewport
+ */
+async function scaleChange(
+    newViewport: PageViewport,
+    oldViewport: PageViewport
+) {
+    if (!highResolutionctx.value) return;
 
     const originScaleCanvas = copyCanvas(highResolutionctx.value);
+    const { width, height } = newViewport;
 
-    const { width, height } = viewport;
     setPageSize(width, height);
-
-    drawLowResolutionLayer(originScaleCanvas, viewport, oldViewport);
-    await drawHighResolutionLayer(viewport);
+    drawLowResolutionLayer(originScaleCanvas, newViewport, oldViewport);
+    await drawHighResolutionLayer(newViewport);
     await renderTextLayer();
 }
 function setPageSize(width: number, height: number) {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -60,12 +60,9 @@ let originalPageSize: SizeType = {
 
 const debouncedHighResolutionRender = createDebounce(
     async (newPageSize: SizeType) => {
-        $highResolutionLayer.value.width = newPageSize.width;
-        $highResolutionLayer.value.height = newPageSize.height;
-        $selectionLayer.value.$el.width = newPageSize.width;
-        $selectionLayer.value.$el.height = newPageSize.height;
-        $highlightLayer.value.$el.width = newPageSize.width;
-        $highlightLayer.value.$el.height = newPageSize.height;
+        resizeCanvas($highResolutionLayer.value, newPageSize);
+        resizeCanvas($selectionLayer.value, newPageSize);
+        resizeCanvas($highlightLayer.value, newPageSize);
         $textLayer.value.style.width = Math.floor(newPageSize.width) + 'px';
         $textLayer.value.style.height = Math.floor(newPageSize.height) + 'px';
 
@@ -127,8 +124,7 @@ async function changePageSize(newPageSize: SizeType) {
     const originScaleCanvas = copyCanvas(highResolutionCtx.value);
     const { width, height } = newPageSize;
 
-    $lowResolutionLayer.value.width = width;
-    $lowResolutionLayer.value.height = height;
+    resizeCanvas($lowResolutionLayer.value, newPageSize);
     $pdfPage.value.style.width = Math.floor(width) + 'px';
     $pdfPage.value.style.height = Math.floor(height) + 'px';
     lowResolutionCtx.value.scale(
@@ -138,7 +134,7 @@ async function changePageSize(newPageSize: SizeType) {
     drawLowResolutionLayer(originScaleCanvas);
     debouncedHighResolutionRender(newPageSize);
 }
-function setPageSize({ width, height }: SizeType) {
+function setPageSize(pageSize: SizeType) {
     if (
         !$pdfPage.value ||
         !$highResolutionLayer.value ||
@@ -148,18 +144,14 @@ function setPageSize({ width, height }: SizeType) {
     )
         return;
 
-    $pdfPage.value.style.width = width + 'px';
-    $pdfPage.value.style.height = height + 'px';
-    $lowResolutionLayer.value.width = width;
-    $lowResolutionLayer.value.height = height;
-    $highResolutionLayer.value.width = width;
-    $highResolutionLayer.value.height = height;
-    $selectionLayer.value.$el.width = width;
-    $selectionLayer.value.$el.height = height;
-    $highlightLayer.value.$el.width = width;
-    $highlightLayer.value.$el.height = height;
-    $textLayer.value.style.width = width + 'px';
-    $textLayer.value.style.height = height + 'px';
+    $pdfPage.value.style.width = pageSize.width + 'px';
+    $pdfPage.value.style.height = pageSize.height + 'px';
+    resizeCanvas($lowResolutionLayer.value, pageSize);
+    resizeCanvas($highResolutionLayer.value, pageSize);
+    resizeCanvas($selectionLayer.value.$el, pageSize);
+    resizeCanvas($highlightLayer.value.$el, pageSize);
+    $textLayer.value.style.width = pageSize.width + 'px';
+    $textLayer.value.style.height = pageSize.height + 'px';
 }
 
 function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {
@@ -184,6 +176,13 @@ async function renderTextLayer() {
 
     await page.renderTextLayer($textLayer.value);
     page.addTokenInfo($textLayer.value);
+}
+
+function resizeCanvas(canvas: HTMLCanvasElement | undefined, size: SizeType) {
+    if (!canvas) return;
+
+    canvas.width = size.width;
+    canvas.height = size.height;
 }
 </script>
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -34,6 +34,7 @@ import { usePdfStore } from '@/store/pdf';
 import SelectionLayer from '@/components/layer/SelectionLayer.vue';
 import HighlightLayer from '@/components/layer/HighlightLayer.vue';
 import Page from '@/classes/Page';
+import copyCanvas from '@/utils/copyCanvas';
 import { PageViewport } from 'pdfjs-dist';
 
 const props = defineProps({
@@ -120,18 +121,6 @@ function setPageSize(width: number, height: number) {
     $highlightLayer.value.$el.height = height;
     $textLayer.value.style.width = width + 'px';
     $textLayer.value.style.height = height + 'px';
-}
-
-function copyCanvas(ctx: CanvasRenderingContext2D) {
-    const { width, height } = ctx.canvas;
-    const originImg = ctx.getImageData(0, 0, width, height);
-    const copiedCanvas = document.createElement('canvas');
-
-    copiedCanvas.width = width;
-    copiedCanvas.height = height;
-    copiedCanvas.getContext('2d')?.putImageData(originImg, 0, 0);
-
-    return copiedCanvas;
 }
 
 function drawLowResolutionLayer(

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -36,6 +36,7 @@ import HighlightLayer from '@/components/layer/HighlightLayer.vue';
 import copyCanvas from '@/utils/copyCanvas';
 import Page from '@/classes/Page';
 import createDebounce from '@/utils/createDebounce';
+import { SizeType } from '@/types/SizeType';
 
 const props = defineProps({
     pageIndex: {
@@ -44,10 +45,6 @@ const props = defineProps({
     },
 });
 
-type Size = {
-    width: number;
-    height: number;
-};
 const isChangingSize = ref<boolean>(false);
 const pdfStore = usePdfStore();
 const $pdfPage = ref<HTMLDivElement>();
@@ -56,13 +53,13 @@ const $lowResolutionLayer = ref<HTMLCanvasElement>();
 const $textLayer = ref<HTMLDivElement>();
 const $selectionLayer = ref();
 const $highlightLayer = ref();
-let originalPageSize: Size = {
+let originalPageSize: SizeType = {
     width: 0,
     height: 0,
 };
 
 const debouncedHighResolutionRender = createDebounce(
-    async (newPageSize: Size) => {
+    async (newPageSize: SizeType) => {
         $highResolutionLayer.value.width = newPageSize.width;
         $highResolutionLayer.value.height = newPageSize.height;
         $selectionLayer.value.$el.width = newPageSize.width;
@@ -107,7 +104,7 @@ onMounted(async () => {
         if (!newViewport) return;
 
         isChangingSize.value = true;
-        const newPageSize: Size = {
+        const newPageSize: SizeType = {
             width: newViewport.width,
             height: newViewport.height,
         };
@@ -119,7 +116,7 @@ onMounted(async () => {
  * canvas확대/축소 (해상도가 낮아짐) -> 고해상도 canvas를 로딩
  * @param newPageSize
  */
-async function changePageSize(newPageSize: Size) {
+async function changePageSize(newPageSize: SizeType) {
     if (
         !highResolutionCtx.value ||
         !lowResolutionCtx.value ||
@@ -141,7 +138,7 @@ async function changePageSize(newPageSize: Size) {
     drawLowResolutionLayer(originScaleCanvas);
     debouncedHighResolutionRender(newPageSize);
 }
-function setPageSize({ width, height }: Size) {
+function setPageSize({ width, height }: SizeType) {
     if (
         !$pdfPage.value ||
         !$highResolutionLayer.value ||
@@ -171,7 +168,7 @@ function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {
     lowResolutionCtx.value.drawImage(originScaleCanvas, 0, 0);
 }
 
-async function drawHighResolutionLayer({ width, height }: Size) {
+async function drawHighResolutionLayer({ width, height }: SizeType) {
     if (!page || !highResolutionCtx.value) return;
 
     const tempCanvas = document.createElement('canvas');

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -53,7 +53,7 @@ const isRendering = ref<boolean>(false);
 
 let page: Page | undefined;
 let ctx: CanvasRenderingContext2D | null = null;
-let tempCtx: CanvasRenderingContext2D | null = null;
+let lowResolutionCtx: CanvasRenderingContext2D | null = null;
 onMounted(async () => {
     page = await pdfStore.getPage(props.pageIndex);
     if (
@@ -65,7 +65,7 @@ onMounted(async () => {
         return;
 
     ctx = $pdfLayer.value.getContext('2d');
-    tempCtx = $lowResolutionLayer.value.getContext('2d');
+    lowResolutionCtx = $lowResolutionLayer.value.getContext('2d');
 
     if (!page.viewport.value) return;
 
@@ -85,7 +85,13 @@ onMounted(async () => {
 });
 
 async function renderPage(viewport: PageViewport, oldViewport: PageViewport) {
-    if (!page || !ctx || !tempCtx || !$pdfLayer.value || !$textLayer.value)
+    if (
+        !page ||
+        !ctx ||
+        !lowResolutionCtx ||
+        !$pdfLayer.value ||
+        !$textLayer.value
+    )
         return;
 
     // 이전 캔버스,viewport 정보
@@ -96,11 +102,11 @@ async function renderPage(viewport: PageViewport, oldViewport: PageViewport) {
     setPageSize(width, height);
 
     // 저해상도 스케일의 pdf 올림
-    tempCtx.scale(
+    lowResolutionCtx.scale(
         viewport.width / oldViewport.width,
         viewport.height / oldViewport.height
     );
-    tempCtx.drawImage(prevCanvas, 0, 0);
+    lowResolutionCtx.drawImage(prevCanvas, 0, 0);
 
     // 고해상도 스케일의 pdf 로딩
     const newCanvas = document.createElement('canvas');

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -56,6 +56,19 @@ onMounted(async () => {
     page.addTokenInfo($textLayer.value);
 });
 
+pdfStore.$subscribe(async (_, state) => {
+    page = await pdfStore.getPage(props.pageIndex);
+
+    if (!page || !$pdfLayer.value || !$textLayer.value) return;
+
+    page.updateViewport(state.viewportOption);
+    const { width, height } = page.viewport;
+    setPageSize(width, height);
+    await page.renderPdfLayer($pdfLayer.value);
+    await page.renderTextLayer($textLayer.value);
+    page.addTokenInfo($textLayer.value);
+});
+
 function setPageSize(width: number, height: number) {
     if (
         !$pdfPage.value ||

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -35,10 +35,10 @@ import SelectionLayer from '@/components/layer/SelectionLayer.vue';
 import HighlightLayer from '@/components/layer/HighlightLayer.vue';
 import copyCanvas from '@/utils/copyCanvas';
 import createDebounce from '@/utils/createDebounce';
-import { SizeType } from '@/types/SizeType';
 import resizeCanvas from '@/utils/resizeCanvas';
 import resizeElement from '@/utils/resizeElement';
 import rescaleCanvas from '@/utils/rescaleCanvas';
+import { SizeType } from '@/types/SizeType';
 
 const props = defineProps({
     pageIndex: {
@@ -50,9 +50,9 @@ const props = defineProps({
 const isChangingSize = ref<boolean>(false);
 const pdfStore = usePdfStore();
 const $pdfPage = ref<HTMLDivElement>();
+const $textLayer = ref<HTMLDivElement>();
 const $highResolutionLayer = ref<HTMLCanvasElement>();
 const $lowResolutionLayer = ref<HTMLCanvasElement>();
-const $textLayer = ref<HTMLDivElement>();
 const $selectionLayer = ref();
 const $highlightLayer = ref();
 
@@ -79,11 +79,11 @@ onMounted(async () => {
     const page = await pdfStore.getPage(props.pageIndex);
     if (!page) return;
 
-    originalPageSize = page.size;
     await renderPage(page.size);
 
     watch(page.viewport, async () => {
-        await changePageSize(page.size);
+        const newSize = page.size;
+        await changePageSize(newSize);
     });
 });
 /**
@@ -99,6 +99,7 @@ async function changePageSize(newPageSize: SizeType) {
 }
 
 async function renderPage(pageSize: SizeType) {
+    originalPageSize = pageSize;
     resizeElement($pdfPage.value, pageSize);
     resizeCanvas($selectionLayer.value.$el, pageSize);
     resizeCanvas($highlightLayer.value.$el, pageSize);
@@ -121,8 +122,6 @@ async function renderHighResolutionLayer(pageSize: SizeType) {
     if (!page) return;
 
     resizeCanvas($highResolutionLayer.value, pageSize);
-
-    originalPageSize = pageSize;
 
     const newPdfLayer = await page.createPdfLayer();
     drawHighResolutionLayer(newPdfLayer);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -159,12 +159,11 @@ function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {
     lowResolutionCtx.value.drawImage(originScaleCanvas, 0, 0);
 }
 
-async function drawHighResolutionLayer({ width, height }: SizeType) {
+async function drawHighResolutionLayer(pageSize: SizeType) {
     if (!page || !highResolutionCtx.value) return;
 
     const tempCanvas = document.createElement('canvas');
-    tempCanvas.width = width;
-    tempCanvas.height = height;
+    resizeCanvas(tempCanvas, pageSize);
     await page.renderPdfLayer(tempCanvas);
 
     highResolutionCtx.value.drawImage(tempCanvas, 0, 0);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -178,7 +178,7 @@ function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {
     lowResolutionCtx.value.drawImage(originScaleCanvas, 0, 0);
 }
 
-async function drawHighResolutionLayer({ width, height }: PageViewport) {
+async function drawHighResolutionLayer({ width, height }: Size) {
     if (!page || !highResolutionCtx.value) return;
 
     const tempCanvas = document.createElement('canvas');

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -52,7 +52,7 @@ const $lowResolutionLayer = ref<HTMLCanvasElement>();
 const isScaleChanging = ref<boolean>(false);
 
 let page: Page | undefined;
-const ctx = computed<CanvasRenderingContext2D | null>(() => {
+const highResolutionctx = computed<CanvasRenderingContext2D | null>(() => {
     if (!$highResolutionLayer.value) return null;
     return $highResolutionLayer.value.getContext('2d');
 });
@@ -82,14 +82,14 @@ onMounted(async () => {
 async function scaleChange(viewport: PageViewport, oldViewport: PageViewport) {
     if (
         !page ||
-        !ctx.value ||
+        !highResolutionctx.value ||
         !lowResolutionCtx.value ||
         !$highResolutionLayer.value ||
         !$textLayer.value
     )
         return;
 
-    const originScaleCanvas = copyCanvas(ctx.value);
+    const originScaleCanvas = copyCanvas(highResolutionctx.value);
 
     const { width, height } = viewport;
     setPageSize(width, height);
@@ -150,15 +150,14 @@ function drawLowResolutionLayer(
 }
 
 async function drawHighResolutionLayer(viewport: PageViewport) {
-    if (!page || !ctx.value) return;
+    if (!page || !highResolutionctx.value) return;
 
     const newCanvas = document.createElement('canvas');
     newCanvas.width = viewport.width;
     newCanvas.height = viewport.height;
     await page.renderPdfLayer(newCanvas);
 
-    // 고해상도 스케일 pdf 그림
-    ctx.value.drawImage(newCanvas, 0, 0);
+    highResolutionctx.value.drawImage(newCanvas, 0, 0);
 }
 
 async function renderTextLayer() {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -4,7 +4,7 @@
         <canvas
             ref="$lowResolutionLayer"
             class="lowResolutionLayer"
-            :class="{ show: isScaleChanging }"
+            :class="{ show: isChangingSize }"
         ></canvas>
         <div
             ref="$textLayer"
@@ -49,7 +49,7 @@ type Size = {
     width: number;
     height: number;
 };
-const isScaleChanging = ref<boolean>(false);
+const isChangingSize = ref<boolean>(false);
 const pdfStore = usePdfStore();
 const $pdfPage = ref<HTMLDivElement>();
 const $highResolutionLayer = ref<HTMLCanvasElement>();
@@ -79,7 +79,7 @@ const debouncedHighResolutionRender = createDebounce(
         };
         await drawHighResolutionLayer(newPageSize);
         if ($highResolutionLayer.value) {
-            isScaleChanging.value = false;
+            isChangingSize.value = false;
             drawLowResolutionLayer($highResolutionLayer.value);
         }
         await renderTextLayer();
@@ -113,7 +113,7 @@ onMounted(async () => {
     watch(page.viewport, async (newViewport, oldViewport) => {
         if (!newViewport || !oldViewport) return;
 
-        isScaleChanging.value = true;
+        isChangingSize.value = true;
         const newPageSize: Size = {
             width: newViewport.width,
             height: newViewport.height,

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -162,7 +162,6 @@ async function drawHighResolutionLayer() {
     if (!page || !highResolutionCtx.value) return;
 
     const tempCanvas = document.createElement('canvas');
-    resizeCanvas(tempCanvas, page.size);
     await page.renderPdfLayer(tempCanvas);
 
     highResolutionCtx.value.drawImage(tempCanvas, 0, 0);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -72,9 +72,7 @@ let originalPageSize: SizeType = {
 
 const debouncedRenderPage = createDebounce(async (newPageSize: SizeType) => {
     await renderPage(newPageSize);
-    // await renderHighResolutionLayer(newPageSize);
     isChangingSize.value = false;
-    await renderTextLayer(newPageSize);
 }, 500);
 
 onMounted(async () => {
@@ -107,6 +105,7 @@ async function renderPage(pageSize: SizeType) {
     resizeCanvas($highlightLayer.value.$el, pageSize);
 
     await renderHighResolutionLayer(pageSize);
+    await renderTextLayer(pageSize);
 }
 function renderLowResolutionLayer(pageSize: SizeType) {
     const originCanvas = copyCanvas($highResolutionLayer.value);
@@ -128,10 +127,6 @@ async function renderHighResolutionLayer(pageSize: SizeType) {
 
     const newPdfLayer = await page.createPdfLayer();
     drawHighResolutionLayer(newPdfLayer);
-
-    if ($highResolutionLayer.value) {
-        drawLowResolutionLayer($highResolutionLayer.value);
-    }
 }
 
 function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -53,7 +53,7 @@ const $lowResolutionLayer = ref<HTMLCanvasElement>();
 const isScaleChanging = ref<boolean>(false);
 
 let page: Page | undefined;
-const highResolutionctx = computed<CanvasRenderingContext2D | null>(() => {
+const highResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
     if (!$highResolutionLayer.value) return null;
     return $highResolutionLayer.value.getContext('2d');
 });
@@ -90,9 +90,9 @@ async function scaleChange(
     newViewport: PageViewport,
     oldViewport: PageViewport
 ) {
-    if (!highResolutionctx.value) return;
+    if (!highResolutionCtx.value) return;
 
-    const originScaleCanvas = copyCanvas(highResolutionctx.value);
+    const originScaleCanvas = copyCanvas(highResolutionCtx.value);
     const { width, height } = newViewport;
 
     setPageSize(width, height);
@@ -139,14 +139,14 @@ function drawLowResolutionLayer(
 }
 
 async function drawHighResolutionLayer(viewport: PageViewport) {
-    if (!page || !highResolutionctx.value) return;
+    if (!page || !highResolutionCtx.value) return;
 
     const tempCanvas = document.createElement('canvas');
     tempCanvas.width = viewport.width;
     tempCanvas.height = viewport.height;
     await page.renderPdfLayer(tempCanvas);
 
-    highResolutionctx.value.drawImage(tempCanvas, 0, 0);
+    highResolutionCtx.value.drawImage(tempCanvas, 0, 0);
 }
 
 async function renderTextLayer() {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -34,7 +34,6 @@ import { usePdfStore } from '@/store/pdf';
 import SelectionLayer from '@/components/layer/SelectionLayer.vue';
 import HighlightLayer from '@/components/layer/HighlightLayer.vue';
 import copyCanvas from '@/utils/copyCanvas';
-import Page from '@/classes/Page';
 import createDebounce from '@/utils/createDebounce';
 import { SizeType } from '@/types/SizeType';
 import resizeCanvas from '@/utils/resizeCanvas';
@@ -55,6 +54,16 @@ const $lowResolutionLayer = ref<HTMLCanvasElement>();
 const $textLayer = ref<HTMLDivElement>();
 const $selectionLayer = ref();
 const $highlightLayer = ref();
+
+const highResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
+    if (!$highResolutionLayer.value) return null;
+    return $highResolutionLayer.value.getContext('2d');
+});
+const lowResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
+    if (!$lowResolutionLayer.value) return null;
+    return $lowResolutionLayer.value.getContext('2d');
+});
+
 let originalPageSize: SizeType = {
     width: 0,
     height: 0,
@@ -83,15 +92,6 @@ const debouncedHighResolutionRender = createDebounce(
     },
     500
 );
-
-const highResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
-    if (!$highResolutionLayer.value) return null;
-    return $highResolutionLayer.value.getContext('2d');
-});
-const lowResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
-    if (!$lowResolutionLayer.value) return null;
-    return $lowResolutionLayer.value.getContext('2d');
-});
 
 onMounted(async () => {
     /**

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -89,18 +89,16 @@ const lowResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
 
 onMounted(async () => {
     page = await pdfStore.getPage(props.pageIndex);
-    if (!page || !page.viewport.value || !$highResolutionLayer.value) return;
+
+    if (!page) return;
 
     originalPageSize = page.size;
-
     setPageSize(originalPageSize);
     await drawHighResolutionLayer(originalPageSize);
     await renderTextLayer();
 
     watch(page.viewport, async (newViewport) => {
         if (!newViewport) return;
-
-        isChangingSize.value = true;
         const newPageSize: SizeType = {
             width: newViewport.width,
             height: newViewport.height,
@@ -121,6 +119,7 @@ async function changePageSize(newPageSize: SizeType) {
     )
         return;
 
+    isChangingSize.value = true;
     const originScaleCanvas = copyCanvas(highResolutionCtx.value);
     const { width, height } = newPageSize;
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -48,10 +48,10 @@ const isScaleChanging = ref<boolean>(false);
 const pdfStore = usePdfStore();
 const $pdfPage = ref<HTMLDivElement>();
 const $highResolutionLayer = ref<HTMLCanvasElement>();
+const $lowResolutionLayer = ref<HTMLCanvasElement>();
 const $textLayer = ref<HTMLDivElement>();
 const $selectionLayer = ref();
 const $highlightLayer = ref();
-const $lowResolutionLayer = ref<HTMLCanvasElement>();
 
 let page: Page | undefined;
 const highResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -88,7 +88,8 @@ onMounted(async () => {
 });
 /**
  * changePageSize PDF 페이지의 크기를 변경하는 로직으로 아래의 과정을 거칩니다.
- * canvas확대/축소 (해상도가 낮아짐) -> 고해상도 canvas를 랜더링
+ * 1. 저해상도 레이어 로딩(캔버스 확대/축소로 해상도가 낮아짐)
+ * 2. 고해상도 canvas를 랜더링한 뒤 저해상도 레이어를 숨김
  * @param newPageSize
  */
 async function changePageSize(newPageSize: SizeType) {
@@ -97,7 +98,11 @@ async function changePageSize(newPageSize: SizeType) {
     renderLowResolutionLayer(newPageSize);
     debouncedRenderPage(newPageSize);
 }
-
+/**
+ * renderPage는 입력된 사이즈로 페이지를 랜더링합니다.
+ * 저해상도 레이어(lowResolutionLayer) 랜더링은 포함하지 않습니다.
+ * @param pageSize
+ */
 async function renderPage(pageSize: SizeType) {
     originalPageSize = pageSize;
     resizeElement($pdfPage.value, pageSize);
@@ -107,6 +112,10 @@ async function renderPage(pageSize: SizeType) {
     await renderHighResolutionLayer(pageSize);
     await renderTextLayer(pageSize);
 }
+/**
+ * 저해상도 레이어를 랜더링합니다.
+ * @param pageSize
+ */
 function renderLowResolutionLayer(pageSize: SizeType) {
     const originCanvas = copyCanvas($highResolutionLayer.value);
 
@@ -117,6 +126,10 @@ function renderLowResolutionLayer(pageSize: SizeType) {
         drawLowResolutionLayer(originCanvas);
     }
 }
+/**
+ * 고해상도 레이어를 랜더링합니다.
+ * @param pageSize
+ */
 async function renderHighResolutionLayer(pageSize: SizeType) {
     const page = await pdfStore.getPage(props.pageIndex);
     if (!page) return;
@@ -138,7 +151,10 @@ function drawHighResolutionLayer(highResolutionCanvas: HTMLCanvasElement) {
 
     highResolutionCtx.value.drawImage(highResolutionCanvas, 0, 0);
 }
-
+/**
+ * 텍스트 레이어를 랜더링합니다.
+ * @param pageSize
+ */
 async function renderTextLayer(pageSize: SizeType) {
     const page = await pdfStore.getPage(props.pageIndex);
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -38,6 +38,7 @@ import Page from '@/classes/Page';
 import createDebounce from '@/utils/createDebounce';
 import { SizeType } from '@/types/SizeType';
 import resizeCanvas from '@/utils/resizeCanvas';
+import resizeElement from '@/utils/resizeElement';
 
 const props = defineProps({
     pageIndex: {
@@ -191,12 +192,6 @@ function rescaleCanvas(
 
     const ctx = canvas.getContext('2d');
     ctx?.scale(newSize.width / oldSize.width, newSize.height / oldSize.height);
-}
-function resizeElement(el: HTMLElement | undefined, size: SizeType) {
-    if (!el) return;
-
-    el.style.width = Math.floor(size.width) + 'px';
-    el.style.height = Math.floor(size.height) + 'px';
 }
 </script>
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -62,6 +62,7 @@ let originalPageSize: SizeType = {
 
 const debouncedHighResolutionRender = createDebounce(
     async (newPageSize: SizeType) => {
+        const page = await pdfStore.getPage(props.pageIndex);
         if (!page) return;
 
         resizeCanvas($highResolutionLayer.value, newPageSize);
@@ -83,7 +84,6 @@ const debouncedHighResolutionRender = createDebounce(
     500
 );
 
-let page: Page | undefined;
 const highResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
     if (!$highResolutionLayer.value) return null;
     return $highResolutionLayer.value.getContext('2d');
@@ -100,7 +100,7 @@ onMounted(async () => {
      * 고해상도 페이지를 랜더링하고
      * 텍스트를 랜더링한다.
      */
-    page = await pdfStore.getPage(props.pageIndex);
+    const page = await pdfStore.getPage(props.pageIndex);
 
     if (!page) return;
 
@@ -129,9 +129,10 @@ async function changePageSize(newPageSize: SizeType) {
     isChangingSize.value = true;
     const originScaleCanvas = copyCanvas($highResolutionLayer.value);
 
-    resizeCanvas($lowResolutionLayer.value, newPageSize);
     resizeElement($pdfPage.value, newPageSize);
+    resizeCanvas($lowResolutionLayer.value, newPageSize);
     rescaleCanvas($lowResolutionLayer.value, newPageSize, originalPageSize);
+
     if (originScaleCanvas) {
         drawLowResolutionLayer(originScaleCanvas);
     }

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -38,6 +38,7 @@ import createDebounce from '@/utils/createDebounce';
 import { SizeType } from '@/types/SizeType';
 import resizeCanvas from '@/utils/resizeCanvas';
 import resizeElement from '@/utils/resizeElement';
+import rescaleCanvas from '@/utils/rescaleCanvas';
 
 const props = defineProps({
     pageIndex: {
@@ -169,17 +170,6 @@ async function renderTextLayer() {
     $textLayer.value.innerHTML = '';
     $textLayer.value.appendChild(fragment);
     page.addTokenInfo($textLayer.value);
-}
-
-function rescaleCanvas(
-    canvas: HTMLCanvasElement | undefined,
-    newSize: SizeType,
-    oldSize: SizeType
-) {
-    if (!canvas) return;
-
-    const ctx = canvas.getContext('2d');
-    ctx?.scale(newSize.width / oldSize.width, newSize.height / oldSize.height);
 }
 </script>
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -71,7 +71,7 @@ const debouncedHighResolutionRender = createDebounce(
 
         originalPageSize = newPageSize;
 
-        const newPdfLayer = await page.getPdfLayer();
+        const newPdfLayer = await page.createPdfLayer();
         drawHighResolutionLayer(newPdfLayer);
 
         await renderTextLayer();
@@ -107,7 +107,7 @@ onMounted(async () => {
     originalPageSize = page.size;
     resizePage(originalPageSize);
 
-    const pdfLayer = await page.getPdfLayer();
+    const pdfLayer = await page.createPdfLayer();
     drawHighResolutionLayer(pdfLayer);
     await renderTextLayer();
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -79,12 +79,12 @@ onMounted(async () => {
         if (!newViewport || !oldViewport) return;
 
         isRendering.value = true;
-        await renderPage(newViewport, oldViewport);
+        await scaleChange(newViewport, oldViewport);
         isRendering.value = false;
     });
 });
 
-async function renderPage(viewport: PageViewport, oldViewport: PageViewport) {
+async function scaleChange(viewport: PageViewport, oldViewport: PageViewport) {
     if (
         !page ||
         !ctx ||

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -37,6 +37,7 @@ import copyCanvas from '@/utils/copyCanvas';
 import Page from '@/classes/Page';
 import createDebounce from '@/utils/createDebounce';
 import { SizeType } from '@/types/SizeType';
+import resizeCanvas from '@/utils/resizeCanvas';
 
 const props = defineProps({
     pageIndex: {
@@ -174,12 +175,6 @@ async function renderTextLayer() {
     page.addTokenInfo($textLayer.value);
 }
 
-function resizeCanvas(canvas: HTMLCanvasElement | undefined, size: SizeType) {
-    if (!canvas) return;
-
-    canvas.width = size.width;
-    canvas.height = size.height;
-}
 function rescaleCanvas(
     canvas: HTMLCanvasElement | undefined,
     newSize: SizeType,

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -129,8 +129,7 @@ async function changePageSize(newPageSize: SizeType) {
     if (
         !$highResolutionLayer.value ||
         !lowResolutionCtx.value ||
-        !$lowResolutionLayer.value ||
-        !page
+        !$lowResolutionLayer.value
     )
         return;
 
@@ -147,21 +146,12 @@ async function changePageSize(newPageSize: SizeType) {
     debouncedHighResolutionRender(newPageSize);
 }
 function resizePage(pageSize: SizeType) {
-    if (
-        !$pdfPage.value ||
-        !$highResolutionLayer.value ||
-        !$selectionLayer.value ||
-        !$textLayer.value ||
-        !$lowResolutionLayer.value
-    )
-        return;
-
     resizeElement($pdfPage.value, pageSize);
-    resizeCanvas($lowResolutionLayer.value, pageSize);
     resizeCanvas($highResolutionLayer.value, pageSize);
     resizeCanvas($selectionLayer.value.$el, pageSize);
-    resizeCanvas($highlightLayer.value.$el, pageSize);
     resizeElement($textLayer.value, pageSize);
+    resizeCanvas($lowResolutionLayer.value, pageSize);
+    resizeCanvas($highlightLayer.value.$el, pageSize);
 }
 
 function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -126,13 +126,6 @@ onMounted(async () => {
  * @param newPageSize
  */
 async function changePageSize(newPageSize: SizeType) {
-    if (
-        !$highResolutionLayer.value ||
-        !lowResolutionCtx.value ||
-        !$lowResolutionLayer.value
-    )
-        return;
-
     isChangingSize.value = true;
     const originScaleCanvas = copyCanvas($highResolutionLayer.value);
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -167,11 +167,11 @@ function drawHighResolutionLayer(highResolutionCanvas: HTMLCanvasElement) {
 }
 
 async function renderTextLayer() {
+    const page = await pdfStore.getPage(props.pageIndex);
+
     if (!page || !$textLayer.value) return;
 
     const fragment = await page.createTextLayerFragment();
-    if (!fragment) return;
-
     $textLayer.value.innerHTML = '';
     $textLayer.value.appendChild(fragment);
     page.addTokenInfo($textLayer.value);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -31,7 +31,6 @@
  */
 import { defineProps, ref, onMounted, watch, computed } from 'vue';
 import { usePdfStore } from '@/store/pdf';
-import { PageViewport } from 'pdfjs-dist';
 import SelectionLayer from '@/components/layer/SelectionLayer.vue';
 import HighlightLayer from '@/components/layer/HighlightLayer.vue';
 import copyCanvas from '@/utils/copyCanvas';

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -39,6 +39,7 @@ import resizeCanvas from '@/utils/resizeCanvas';
 import resizeElement from '@/utils/resizeElement';
 import rescaleCanvas from '@/utils/rescaleCanvas';
 import { SizeType } from '@/types/SizeType';
+import PDF from '@/constants/PDF';
 
 const props = defineProps({
     pageIndex: {
@@ -73,7 +74,7 @@ let originalPageSize: SizeType = {
 const debouncedRenderPage = createDebounce(async (newPageSize: SizeType) => {
     await renderPage(newPageSize);
     isChangingSize.value = false;
-}, 500);
+}, PDF.RENDER_LATENCY);
 
 onMounted(async () => {
     const page = await pdfStore.getPage(props.pageIndex);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -76,8 +76,7 @@ onMounted(async () => {
     const { width, height } = page.viewport.value;
     setPageSize(width, height);
     await page.renderPdfLayer($pdfLayer.value);
-    await page.renderTextLayer($textLayer.value);
-    page.addTokenInfo($textLayer.value);
+    await renderTextLayer();
 
     watch(page.viewport, async (newViewport, oldViewport) => {
         if (!newViewport || !oldViewport) return;
@@ -106,8 +105,7 @@ async function scaleChange(viewport: PageViewport, oldViewport: PageViewport) {
     drawLowResolutionLayer(originScaleCanvas, viewport, oldViewport);
     await drawHighResolutionLayer(viewport);
 
-    await page.renderTextLayer($textLayer.value);
-    page.addTokenInfo($textLayer.value);
+    await renderTextLayer();
 }
 function setPageSize(width: number, height: number) {
     if (
@@ -170,6 +168,13 @@ async function drawHighResolutionLayer(viewport: PageViewport) {
 
     // 고해상도 스케일 pdf 그림
     ctx.value.drawImage(newCanvas, 0, 0);
+}
+
+async function renderTextLayer() {
+    if (!page || !$textLayer.value) return;
+
+    await page.renderTextLayer($textLayer.value);
+    page.addTokenInfo($textLayer.value);
 }
 </script>
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -92,7 +92,7 @@ onMounted(async () => {
     if (!page) return;
 
     originalPageSize = page.size;
-    setPageSize(originalPageSize);
+    resizePage(originalPageSize);
     await drawHighResolutionLayer(originalPageSize);
     await renderTextLayer();
 
@@ -131,7 +131,7 @@ async function changePageSize(newPageSize: SizeType) {
     drawLowResolutionLayer(originScaleCanvas);
     debouncedHighResolutionRender(newPageSize);
 }
-function setPageSize(pageSize: SizeType) {
+function resizePage(pageSize: SizeType) {
     if (
         !$pdfPage.value ||
         !$highResolutionLayer.value ||

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -63,8 +63,7 @@ const debouncedHighResolutionRender = createDebounce(
         resizeCanvas($highResolutionLayer.value, newPageSize);
         resizeCanvas($selectionLayer.value, newPageSize);
         resizeCanvas($highlightLayer.value, newPageSize);
-        $textLayer.value.style.width = Math.floor(newPageSize.width) + 'px';
-        $textLayer.value.style.height = Math.floor(newPageSize.height) + 'px';
+        resizeElement($textLayer.value, newPageSize);
 
         originalPageSize = newPageSize;
         await drawHighResolutionLayer(newPageSize);
@@ -121,11 +120,10 @@ async function changePageSize(newPageSize: SizeType) {
 
     isChangingSize.value = true;
     const originScaleCanvas = copyCanvas(highResolutionCtx.value);
-    const { width, height } = newPageSize;
 
     resizeCanvas($lowResolutionLayer.value, newPageSize);
-    $pdfPage.value.style.width = Math.floor(width) + 'px';
-    $pdfPage.value.style.height = Math.floor(height) + 'px';
+    resizeElement($pdfPage.value, newPageSize);
+
     lowResolutionCtx.value.scale(
         newPageSize.width / originalPageSize.width,
         newPageSize.height / originalPageSize.height
@@ -143,14 +141,12 @@ function setPageSize(pageSize: SizeType) {
     )
         return;
 
-    $pdfPage.value.style.width = pageSize.width + 'px';
-    $pdfPage.value.style.height = pageSize.height + 'px';
+    resizeElement($pdfPage.value, pageSize);
     resizeCanvas($lowResolutionLayer.value, pageSize);
     resizeCanvas($highResolutionLayer.value, pageSize);
     resizeCanvas($selectionLayer.value.$el, pageSize);
     resizeCanvas($highlightLayer.value.$el, pageSize);
-    $textLayer.value.style.width = pageSize.width + 'px';
-    $textLayer.value.style.height = pageSize.height + 'px';
+    resizeElement($textLayer.value, pageSize);
 }
 
 function drawLowResolutionLayer(originScaleCanvas: HTMLCanvasElement) {
@@ -181,6 +177,13 @@ function resizeCanvas(canvas: HTMLCanvasElement | undefined, size: SizeType) {
 
     canvas.width = size.width;
     canvas.height = size.height;
+}
+
+function resizeElement(el: HTMLElement | undefined, size: SizeType) {
+    if (!el) return;
+
+    el.style.width = Math.floor(size.width) + 'px';
+    el.style.height = Math.floor(size.height) + 'px';
 }
 </script>
 

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -152,12 +152,12 @@ function drawLowResolutionLayer(
 async function drawHighResolutionLayer(viewport: PageViewport) {
     if (!page || !highResolutionctx.value) return;
 
-    const newCanvas = document.createElement('canvas');
-    newCanvas.width = viewport.width;
-    newCanvas.height = viewport.height;
-    await page.renderPdfLayer(newCanvas);
+    const tempCanvas = document.createElement('canvas');
+    tempCanvas.width = viewport.width;
+    tempCanvas.height = viewport.height;
+    await page.renderPdfLayer(tempCanvas);
 
-    highResolutionctx.value.drawImage(newCanvas, 0, 0);
+    highResolutionctx.value.drawImage(tempCanvas, 0, 0);
 }
 
 async function renderTextLayer() {

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -67,6 +67,7 @@ onMounted(async () => {
     if (!page || !page.viewport.value) return;
 
     const { width, height } = page.viewport.value;
+
     setPageSize(width, height);
     await drawHighResolutionLayer(page.viewport.value);
     await renderTextLayer();

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -98,13 +98,12 @@ onMounted(async () => {
     page = await pdfStore.getPage(props.pageIndex);
     if (!page || !page.viewport.value || !$highResolutionLayer.value) return;
 
-    const { width, height } = page.viewport.value;
     oldSize = {
-        width,
-        height,
+        width: page.viewport.value.width,
+        height: page.viewport.value.height,
     };
 
-    setPageSize(width, height);
+    setPageSize(oldSize);
     await drawHighResolutionLayer(page.viewport.value);
     await renderTextLayer();
 
@@ -143,7 +142,7 @@ async function scaleChange(newViewport: PageViewport) {
     drawLowResolutionLayer(originScaleCanvas);
     debouncedHighResolutionRender(newViewport);
 }
-function setPageSize(width: number, height: number) {
+function setPageSize({ width, height }: Size) {
     if (
         !$pdfPage.value ||
         !$highResolutionLayer.value ||

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -72,10 +72,7 @@ const debouncedHighResolutionRender = createDebounce(
         $textLayer.value.style.width = Math.floor(newPageSize.width) + 'px';
         $textLayer.value.style.height = Math.floor(newPageSize.height) + 'px';
 
-        originalPageSize = {
-            width: newPageSize.width,
-            height: newPageSize.height,
-        };
+        originalPageSize = newPageSize;
         await drawHighResolutionLayer(newPageSize);
         if ($highResolutionLayer.value) {
             isChangingSize.value = false;
@@ -100,10 +97,7 @@ onMounted(async () => {
     page = await pdfStore.getPage(props.pageIndex);
     if (!page || !page.viewport.value || !$highResolutionLayer.value) return;
 
-    originalPageSize = {
-        width: page.viewport.value.width,
-        height: page.viewport.value.height,
-    };
+    originalPageSize = page.size;
 
     setPageSize(originalPageSize);
     await drawHighResolutionLayer(originalPageSize);

--- a/src/components/PdfPage.vue
+++ b/src/components/PdfPage.vue
@@ -63,19 +63,11 @@ const lowResolutionCtx = computed<CanvasRenderingContext2D | null>(() => {
 
 onMounted(async () => {
     page = await pdfStore.getPage(props.pageIndex);
-    if (
-        !page ||
-        !$lowResolutionLayer.value ||
-        !$pdfLayer.value ||
-        !$textLayer.value
-    )
-        return;
-
-    if (!page.viewport.value) return;
+    if (!page || !page.viewport.value) return;
 
     const { width, height } = page.viewport.value;
     setPageSize(width, height);
-    await page.renderPdfLayer($pdfLayer.value);
+    await drawHighResolutionLayer(page.viewport.value);
     await renderTextLayer();
 
     watch(page.viewport, async (newViewport, oldViewport) => {
@@ -104,7 +96,6 @@ async function scaleChange(viewport: PageViewport, oldViewport: PageViewport) {
 
     drawLowResolutionLayer(originScaleCanvas, viewport, oldViewport);
     await drawHighResolutionLayer(viewport);
-
     await renderTextLayer();
 }
 function setPageSize(width: number, height: number) {

--- a/src/constants/PDF.ts
+++ b/src/constants/PDF.ts
@@ -1,4 +1,5 @@
 export default {
     TYPE: 'application/pdf',
     EXTENSION: '.pdf',
+    RENDER_LATENCY: 300,
 };

--- a/src/store/pdf.ts
+++ b/src/store/pdf.ts
@@ -26,6 +26,10 @@ export const usePdfStore = defineStore('pdf', () => {
         numPages.value = doc.numPages;
     });
 
+    watch(viewportOption, (newOption) => {
+        pageMap.forEach((page) => page.updateViewport(newOption));
+    });
+
     async function getPage(pageNum: number) {
         return pageMap.get(pageNum);
     }

--- a/src/store/pdf.ts
+++ b/src/store/pdf.ts
@@ -21,7 +21,7 @@ export const usePdfStore = defineStore('pdf', () => {
         if (!doc) return;
 
         await initPages(doc);
-        console.log(doc);
+
         fileName.value = newFile.name || '';
         numPages.value = doc.numPages;
     });

--- a/src/store/pdf.ts
+++ b/src/store/pdf.ts
@@ -21,7 +21,7 @@ export const usePdfStore = defineStore('pdf', () => {
         if (!doc) return;
 
         await initPages(doc);
-
+        console.log(doc);
         fileName.value = newFile.name || '';
         numPages.value = doc.numPages;
     });

--- a/src/store/pdf.ts
+++ b/src/store/pdf.ts
@@ -55,10 +55,10 @@ export const usePdfStore = defineStore('pdf', () => {
         return doc;
     }
     function increaseScale() {
-        viewportOption.scale += 0.1;
+        viewportOption.scale = Math.round(viewportOption.scale * 10 + 1) / 10;
     }
     function decreaseScale() {
-        viewportOption.scale -= 0.1;
+        viewportOption.scale = Math.round(viewportOption.scale * 10 - 1) / 10;
     }
     return {
         setPdfFile,

--- a/src/store/pdf.ts
+++ b/src/store/pdf.ts
@@ -50,12 +50,21 @@ export const usePdfStore = defineStore('pdf', () => {
 
         return doc;
     }
+    function increaseScale() {
+        viewportOption.scale += 0.1;
+    }
+    function decreaseScale() {
+        viewportOption.scale -= 0.1;
+    }
     return {
         setPdfFile,
         getPage,
+        increaseScale,
+        decreaseScale,
         pageMap,
         pdfFile,
         fileName,
         numPages,
+        viewportOption,
     };
 });

--- a/src/types/SizeType.ts
+++ b/src/types/SizeType.ts
@@ -1,0 +1,4 @@
+export type SizeType = {
+    width: number;
+    height: number;
+};

--- a/src/utils/copyCanvas.ts
+++ b/src/utils/copyCanvas.ts
@@ -1,0 +1,11 @@
+export default function copyCanvas(ctx: CanvasRenderingContext2D) {
+    const { width, height } = ctx.canvas;
+    const originImg = ctx.getImageData(0, 0, width, height);
+    const copiedCanvas = document.createElement('canvas');
+
+    copiedCanvas.width = width;
+    copiedCanvas.height = height;
+    copiedCanvas.getContext('2d')?.putImageData(originImg, 0, 0);
+
+    return copiedCanvas;
+}

--- a/src/utils/copyCanvas.ts
+++ b/src/utils/copyCanvas.ts
@@ -3,7 +3,9 @@
  * @param canvas 복사할 canvas 요소
  * @returns {HTMLCanvasElement | undefined}
  */
-export default function copyCanvas(canvas: HTMLCanvasElement) {
+export default function copyCanvas(canvas: HTMLCanvasElement | undefined) {
+    if (!canvas) return;
+
     const ctx = canvas.getContext('2d');
 
     if (!ctx) return;

--- a/src/utils/copyCanvas.ts
+++ b/src/utils/copyCanvas.ts
@@ -1,4 +1,13 @@
-export default function copyCanvas(ctx: CanvasRenderingContext2D) {
+/**
+ * 캔버스 요소를 복사해 반환합니다.
+ * @param canvas 복사할 canvas 요소
+ * @returns {HTMLCanvasElement | undefined}
+ */
+export default function copyCanvas(canvas: HTMLCanvasElement) {
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) return;
+
     const { width, height } = ctx.canvas;
     const originImg = ctx.getImageData(0, 0, width, height);
     const copiedCanvas = document.createElement('canvas');

--- a/src/utils/rescaleCanvas.ts
+++ b/src/utils/rescaleCanvas.ts
@@ -1,0 +1,18 @@
+import { SizeType } from '@/types/SizeType';
+
+/**
+ * 캔버스의 스케일을 변경한다.
+ * @param $canvas scale을 변결할 캔버스
+ * @param newSize 새 크기
+ * @param oldSize 이전 크기
+ */
+export default function rescaleCanvas(
+    $canvas: HTMLCanvasElement | undefined,
+    newSize: SizeType,
+    oldSize: SizeType
+) {
+    if (!$canvas) return;
+
+    const ctx = $canvas.getContext('2d');
+    ctx?.scale(newSize.width / oldSize.width, newSize.height / oldSize.height);
+}

--- a/src/utils/resizeCanvas.ts
+++ b/src/utils/resizeCanvas.ts
@@ -1,0 +1,11 @@
+import { SizeType } from '@/types/SizeType';
+
+export default function resizeCanvas(
+    canvas: HTMLCanvasElement | undefined,
+    size: SizeType
+) {
+    if (!canvas) return;
+
+    canvas.width = size.width;
+    canvas.height = size.height;
+}

--- a/src/utils/resizeElement.ts
+++ b/src/utils/resizeElement.ts
@@ -1,0 +1,16 @@
+import { SizeType } from '@/types/SizeType';
+
+/**
+ * 요소의 크기를 size로 변경하는 함수
+ * @param el size를 조정할 요소
+ * @param size 조정할 크기
+ */
+export default function resizeElement(
+    el: HTMLElement | undefined,
+    size: SizeType
+) {
+    if (!el) return;
+
+    el.style.width = Math.floor(size.width) + 'px';
+    el.style.height = Math.floor(size.height) + 'px';
+}

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -1,5 +1,10 @@
 <template>
     <div class="pdfView" ref="$pdfView">
+        <div class="header" v-show="pageNumList.length > 0">
+            <button @click="zoomOutHandler">-</button>
+            <span>{{ scalePercent }}%</span>
+            <button @click="zoomInHandler">+</button>
+        </div>
         <div
             class="pageContainer"
             ref="$pageContainer"
@@ -28,7 +33,7 @@
 import PdfPage from '@/components/PdfPage.vue';
 import { useSelectionStore } from '@/store/selection';
 import { usePdfStore } from '@/store/pdf';
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import CLIPBOARD from '@/constants/CLIPBOARD';
 import POPUP from '@/constants/POPUP';
 import SelectionPopup from '@/components/popup/SelectionPopup.vue';
@@ -46,7 +51,9 @@ const $pdfView = ref();
 const $pageContainer = ref();
 const isPopupShow = ref<boolean>(false);
 const pageNumList = ref<number[]>([]);
-
+const scalePercent = computed(() => {
+    return Math.floor(pdfStore.viewportOption.scale * 100);
+});
 onMounted(() => {
     $pdfView.value.addEventListener('mousedown', selectionStartHandler);
     document.addEventListener('selectionchange', selectionChangeHandler);
@@ -138,14 +145,21 @@ function getPopupPosMax(
         y: pageContainerRect.height - popupRect.height,
     };
 }
+function zoomInHandler() {
+    pdfStore.increaseScale();
+}
+function zoomOutHandler() {
+    pdfStore.decreaseScale();
+}
 </script>
 
 <style lang="scss" scoped>
+@import '@/assets/scss/theme';
+
 .pdfView {
     width: inherit;
     height: inherit;
     overflow: scroll;
-    padding-top: 1rem;
     padding-bottom: 10rem;
     .selectionPopup {
         position: absolute;
@@ -157,6 +171,9 @@ function getPopupPosMax(
             opacity: 1;
             z-index: 200;
         }
+    }
+    .header {
+        background-color: $surface-color;
     }
 
     .pageContainer {

--- a/src/views/PdfView.vue
+++ b/src/views/PdfView.vue
@@ -173,6 +173,9 @@ function zoomOutHandler() {
         }
     }
     .header {
+        top: 0;
+        z-index: 10;
+        position: sticky;
         background-color: $surface-color;
     }
 


### PR DESCRIPTION
## 추가된 기능 & 변경 사항
pdf를 확대&축소할 수 있는 버튼 추가
-> 10% 단위로 확대 축소가 가능합니다.

확대 축소 debounce 적용
-> 확대를 여러 번 눌러도 0.3초 내에 중복되는 확대 요청은 1번만 일어납니다. 

## 공유할 문서
https://memorier.atlassian.net/wiki/spaces/MEMORIER/pages/31752205

## Jira 티켓
https://memorier.atlassian.net/browse/GOMGUK-82?atlOrigin=eyJpIjoiYzM3NjNlZDE0MWJmNGUzMzg1MmUyMTAyN2VkNWFjMjEiLCJwIjoiaiJ9

## 데모 사이트

https://ssu-memorier.github.io/gomguk-viewer-fe/
