### PR TITLE
Gomguk 87 하이라이트 크기 반응형으로

### DIFF
--- a/src/classes/Highlight.ts
+++ b/src/classes/Highlight.ts
@@ -1,13 +1,51 @@
-import Line from '@/classes/Line';
 import Color from '@/classes/Color';
+import getSelectedTokens from '@/utils/getSelectedTokens';
 
 export default class Highlight {
-    pageNum: number;
-    lines: Line[];
+    pageNum: number | undefined;
+    startLine: number | undefined;
+    startToken: number | undefined;
+    startOffset: number | undefined;
+    endLine: number | undefined;
+    endToken: number | undefined;
+    endOffset: number | undefined;
     color: Color = Color.YELLOW;
 
-    constructor(pageNum: number, lines: Line[]) {
+    constructor(pageNum: number, range: Range) {
         this.pageNum = pageNum;
-        this.lines = lines;
+        this.startLine = 0;
+        this.endLine = 0;
+
+        const tokens = getSelectedTokens(range);
+        const startToken = tokens[0];
+        const endToken = tokens[tokens.length - 1];
+
+        if (startToken) {
+            this.startLine = startToken.lineNum;
+            this.startToken = startToken.tokenNum;
+            this.startOffset = startToken.startOffset;
+        }
+        if (endToken) {
+            this.endLine = endToken.lineNum;
+            this.endToken = endToken.tokenNum;
+            this.endOffset = endToken.endOffset;
+        }
+    }
+
+    getRange() {
+        const range = new Range();
+        const startToken = document.querySelector(
+            `.textLayer[data-page-index="${this.pageNum}"] span[data-line-num="${this.startLine}"][data-token-num="${this.startToken}"]`
+        );
+        const endToken = document.querySelector(
+            `.textLayer[data-page-index="${this.pageNum}"] span[data-line-num="${this.endLine}"][data-token-num="${this.endToken}"]`
+        );
+
+        if (!startToken?.firstChild || !endToken?.firstChild) return;
+
+        range.setStart(startToken.firstChild, this.startOffset || 0);
+        range.setEnd(endToken.firstChild, this.endOffset || 0);
+
+        return range;
     }
 }

--- a/src/components/popup/SelectionPopup.vue
+++ b/src/components/popup/SelectionPopup.vue
@@ -22,7 +22,6 @@ import { useHighlightStore } from '@/store/highlight';
 import POPUP from '@/constants/POPUP';
 import writeToClipboard from '@/utils/writeToClipboard';
 import Highlight from '@/classes/Highlight';
-import Line from '@/classes/Line';
 
 const translatorStore = useTranslatorStore();
 const selectionStore = useSelectionStore();
@@ -58,9 +57,10 @@ function copyHandler() {
     writeToClipboard(originText);
 }
 function highlightHandler() {
-    const { selectedLines, selectedPageIndex } = selectionStore;
-    const highlight = new Highlight(selectedPageIndex, selectedLines as Line[]);
+    const { range, selectedPageIndex } = selectionStore;
+    if (!range) return;
 
+    const highlight = new Highlight(selectedPageIndex, range);
     highlightStore.addHighlight(highlight);
 }
 </script>


### PR DESCRIPTION
## 추가된 기능 & 변경 사항
### Highlight 객체 수정
하이라이트 객체가 생성자에서  Line[] 을 받는 방식에서 Range를 받는 방식으로 변경되었습니다.
PDF 페이지의 크기가 변경되면 text layer가 새로 렌더링되어 원래 하이라이트가 사용하던 요소를 찾지 못하게 됩니다. 따라서 시작 토큰 번호,라인 번호 등을 저장하게 하여 하이라이트를 그릴 때 text layer에서 다시 토큰을 찾도록 수정했습니다.

### 하이라이트 레이어 동작 수정
하이라이트 레이어가 페이지 크기에 따라 하이라이트를 다시 그리도록 합니다. 페이지 크기에 따른 하이라이트 크기를 다시 계산해야해서 그렇습니다. 또한 text layer가 새로 렌더링 된 뒤에 하이라이트 레이어를 갱신하도록 합니다.
![highlight](https://user-images.githubusercontent.com/40891497/196973473-b7e4261d-7885-422a-8c28-7f66207adfd1.gif)


## 공유할 문서

## Jira 티켓
https://memorier.atlassian.net/browse/GOMGUK-87?atlOrigin=eyJpIjoiMzYxMTEyYzE4Y2I0NDlhYzlmYzlhZmZkMmRjZDQ4NjMiLCJwIjoiaiJ9

## 데모 사이트

https://ssu-memorier.github.io/gomguk-viewer-fe/
