### PR TITLE
feature/ scale 조정값 제한 생성 (최대 500%, 최소 100%)

### DIFF
--- a/src/constants/PDF/index.ts
+++ b/src/constants/PDF/index.ts
@@ -3,4 +3,6 @@ export default {
     EXTENSION: '.pdf',
     RENDER_LATENCY: 300,
     ROOT_MARGIN: '100% 0%',
+    SCALE_MAX: 3,
+    SCALE_MIN: 1,
 };

--- a/src/constants/PDF/index.ts
+++ b/src/constants/PDF/index.ts
@@ -3,6 +3,6 @@ export default {
     EXTENSION: '.pdf',
     RENDER_LATENCY: 300,
     ROOT_MARGIN: '100% 0%',
-    SCALE_MAX: 3,
+    SCALE_MAX: 5,
     SCALE_MIN: 1,
 };

--- a/src/store/pdf.ts
+++ b/src/store/pdf.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia';
 import { ref, reactive, watch } from 'vue';
 import getBase64 from '@/utils/getBase64';
 import Page from '@/classes/Page';
+import PDF from '@/constants/PDF';
 
 export const usePdfStore = defineStore('pdf', () => {
     const pdfFile = ref<File>();
@@ -55,10 +56,20 @@ export const usePdfStore = defineStore('pdf', () => {
         return doc;
     }
     function increaseScale() {
-        viewportOption.scale = Math.round(viewportOption.scale * 10 + 1) / 10;
+        const newScale = Math.round(viewportOption.scale * 10 + 1) / 10;
+        if (newScale > PDF.SCALE_MAX) {
+            return;
+        }
+
+        viewportOption.scale = newScale;
     }
     function decreaseScale() {
-        viewportOption.scale = Math.round(viewportOption.scale * 10 - 1) / 10;
+        const newScale = Math.round(viewportOption.scale * 10 - 1) / 10;
+        if (newScale < PDF.SCALE_MIN) {
+            return;
+        }
+
+        viewportOption.scale = newScale;
     }
     return {
         setPdfFile,


### PR DESCRIPTION
## 추가된 기능 & 변경 사항
축소시 highlight가 이상해지는 버그가 있고 극히 큰 크기의 PDF나 극히 작은 크기로 PDF를 이용하는 경우는 없을 것이라 판단해 최대 확대 크기, 최소 축소 크기를 제한했습니다.

최소 100%, 최대 500%로 제한합니다.

## 공유할 문서
https://memorier.atlassian.net/wiki/spaces/MEMORIER/pages/37847041

## Jira 티켓
https://memorier.atlassian.net/browse/GOMGUK-97?atlOrigin=eyJpIjoiNjk5Njc5NWUxZjc4NDZjNWI2MjVhOGNjODgwZjBkNzkiLCJwIjoiaiJ9

## 데모 사이트

https://ssu-memorier.github.io/gomguk-viewer-fe/
