### PR TITLE
Gomguk 131 프론트 크기 제한

### DIFF
--- a/src/components/button/PdfLoadButton.vue
+++ b/src/components/button/PdfLoadButton.vue
@@ -29,13 +29,22 @@ function loadFileHandler(e: Event) {
     const fileList = $input.files;
 
     if (!fileList || fileList.length <= 0) return;
-    if (!isPdfFile(fileList[0])) return;
 
-    emit('load', fileList[0]);
+    const file = fileList[0];
+    if (!isPdfFile(file)) return;
+    if (isExceedLimit(file)) {
+        return;
+    }
+
+    emit('load', file);
 }
 
 function isPdfFile(file: File): boolean {
     return file.type === PDF.TYPE;
+}
+
+function isExceedLimit(file: File): boolean {
+    return file.size > PDF.MAX_FILE_SIZE;
 }
 </script>
 

--- a/src/components/button/PdfLoadButton.vue
+++ b/src/components/button/PdfLoadButton.vue
@@ -17,7 +17,7 @@
  */
 import { defineEmits } from 'vue';
 import PDF from '@/constants/PDF';
-
+import MESSAGE from '@/constants/MESSAGE';
 const emit = defineEmits<{
     (e: 'load', file: File): void;
 }>();
@@ -33,6 +33,7 @@ function loadFileHandler(e: Event) {
     const file = fileList[0];
     if (!isPdfFile(file)) return;
     if (isExceedLimit(file)) {
+        window.alert(MESSAGE.PDF.EXCEED_LIMIT);
         return;
     }
 

--- a/src/components/button/PdfLoadButton.vue
+++ b/src/components/button/PdfLoadButton.vue
@@ -31,7 +31,10 @@ function loadFileHandler(e: Event) {
     if (!fileList || fileList.length <= 0) return;
 
     const file = fileList[0];
-    if (!isPdfFile(file)) return;
+    if (!isPdfFile(file)) {
+        window.alert(MESSAGE.PDF.IS_NOT_PDF);
+        return;
+    }
     if (isExceedLimit(file)) {
         window.alert(MESSAGE.PDF.EXCEED_LIMIT);
         return;

--- a/src/constants/MESSAGE.ts
+++ b/src/constants/MESSAGE.ts
@@ -6,4 +6,7 @@ export default {
         DELETE_FAILED: '파일을 삭제하는데 실패했습니다.',
         UPDATE_FAILED: '파일을 저장하는데 실패했습니다.',
     },
+    PDF: {
+        EXCEED_LIMIT: '파일은 최대 20MB 까지만 올릴 수 있습니다',
+    },
 };

--- a/src/constants/MESSAGE.ts
+++ b/src/constants/MESSAGE.ts
@@ -7,6 +7,7 @@ export default {
         UPDATE_FAILED: '파일을 저장하는데 실패했습니다.',
     },
     PDF: {
+        IS_NOT_PDF: 'PDF 파일만 올릴 수 있습니다',
         EXCEED_LIMIT: '파일은 최대 20MB 까지만 올릴 수 있습니다',
     },
 };

--- a/src/constants/PDF/index.ts
+++ b/src/constants/PDF/index.ts
@@ -5,4 +5,5 @@ export default {
     ROOT_MARGIN: '100% 0%',
     SCALE_MAX: 5,
     SCALE_MIN: 1,
+    MAX_FILE_SIZE: 20 * 1024 * 1024,
 };


### PR DESCRIPTION
## 추가된 기능 & 변경 사항

20MB가 넘어가는 파일은 올릴 수 없도록 제한합니다.

불러오는 파일이 PDF가 아닌 경우, 파일 크기가 20MB가 넘어가는 경우 경고창을 띄우고 파일을 올리지 못하게 막습니다.
![image](https://user-images.githubusercontent.com/40891497/201678540-3a2ccc8b-431a-4f7a-8603-643bc9c5737e.png)
![image](https://user-images.githubusercontent.com/40891497/201678818-a1a3a799-c487-4c25-920c-030d9bb543c3.png)

## 공유할 문서

## Jira 티켓
https://memorier.atlassian.net/browse/GOMGUK-131?atlOrigin=eyJpIjoiMGVhYjkyNTU3ODczNGFjYWFkZjIwZDMyM2EwZTgyYjYiLCJwIjoiaiJ9

## 데모 사이트

https://ssu-memorier.github.io/gomguk-viewer-fe/
