### PR TITLE
feature/ 유저 인증 실패(401)시 로그인 상태 해제

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,12 +54,34 @@ import { useFileStore } from '@/store/file';
 import { useUserStore } from '@/store/user';
 import HEADER from '@/constants/HEADER';
 import MESSAGE from '@/constants/MESSAGE';
+/**
+ * TODO: 제거 예정
+ */
+import axios from 'axios';
 
 const $main = ref();
 
 const modalStore = useModalStore();
 const fileStore = useFileStore();
 const userStore = useUserStore();
+
+/**
+ * TODO: 추후 제거 예정
+ *
+ * 아래 로직은 ajax 요청의 결과가 401인 경우 로그아웃을 시키는 로직으로 추후 get~~Model 유틸에 흡수할 예정입니다.
+ * 현재는 model이 여러 곳으로 쪼개져 있어 임시로 이 곳에서 401을 처리하도록 하지만
+ * 추후 gateway를 통해 통합된 model을 제공할 예정이기 때문에 그 때 이 로직을 제거하고 통합된 model에서 401을 처리하게 할 것입니다.
+ */
+axios.interceptors.response.use(
+    (response) => {
+        return response;
+    },
+    (err) => {
+        if (err.response.status === 401) {
+            userStore.isLoggined = false;
+        }
+    }
+);
 
 onMounted(async () => {
     await userStore.getProfile();


### PR DESCRIPTION
## 추가된 기능 & 변경 사항

401에러 발생시 로그인 상태를 해제합니다.
현재는 App.vue에서 401에러 처리 로직을 추가합니다.

추후 model이 gateway로 통합되면 model을 생성하는 로직에서 401을 처리하도록 수정할 예정이므로 임시로 App.vue에 위치한다고 생각하면 됩니다.

## 공유할 문서

## Jira 티켓
https://memorier.atlassian.net/browse/GOMGUK-145?atlOrigin=eyJpIjoiM2Y0OWJiMDBjOWJkNDhkYmE5ODQxMDBmYjIzYjZmMDUiLCJwIjoiaiJ9
## 데모 사이트

https://ssu-memorier.github.io/gomguk-viewer-fe/
